### PR TITLE
build: migrate from mypy to pyright

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -113,7 +113,7 @@ uv run ruff format
 Run type checking:
 
 ```sh
-uv run mypy .
+uv run pyright .
 ```
 
 ## Build

--- a/.gitignore
+++ b/.gitignore
@@ -146,11 +146,6 @@ venv.bak/
 # mkdocs documentation
 /site
 
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
 # Pyre type checker
 .pyre/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,11 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+  - repo: local
     hooks:
-      - id: mypy
-        entry: bash -c 'uv run mypy .'
+      - id: pyright
+        name: pyright
+        entry: uv run pyright .
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ docs = [
     "pdoc==16.0.0",
 ]
 lint = [
-    "mypy==2.3.0",
     "pre-commit==4.6.0",
+    "pyright==1.1.411",
     "ruff==0.15.21",
 ]
 test = [
@@ -53,12 +53,8 @@ ignore = [
     "E501",  # line too long (handled by ruff)
 ]
 
-[tool.mypy]
-strict = true
-ignore_missing_imports = true
-exclude = [
-    '^tests/.*'
-]
+[tool.pyright]
+typeCheckingMode = "strict"
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
Replace mypy with pyright as the project type checker.

## Changes

- Replace `mypy==2.3.0` with `pyright==1.1.411` in lint dependencies
- Add `[tool.pyright]` with `typeCheckingMode = "strict"`
- Remove `[tool.mypy]` section
- Update pre-commit hook from `mirrors-mypy` to a local pyright hook
- Update CONTRIBUTING.md type-check command
- Remove mypy cache entries from .gitignore